### PR TITLE
Transfer matrix data between Python and Scala using Arrow extension types

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,16 +25,24 @@ lazy val commonSettings = Seq(
   fork := true,
   Test / fork := true,
   Test / parallelExecution := false,
-  Test / testOptions += Tests.Argument("-oDF")
+  Test / testOptions += Tests.Argument("-oDF"),
+  shellPrompt := { s => Project.extract(s).currentProject.id + " > " },
+  ThisBuild / useCoursier := false
 )
 
-lazy val root = Project("geotrellis-contrib", file("."))
+lazy val root = Project("py2j-arrow", file("."))
   .aggregate(py4, pyj)
   .settings(commonSettings: _*)
 
 lazy val py4 = project
   .settings(commonSettings)
-  .settings(libraryDependencies += "net.sf.py4j" % "py4j" % "0.10.8.1")
+  .settings(libraryDependencies ++=
+     Seq(
+        "net.sf.py4j" % "py4j" % "0.10.8.1",
+        "org.nd4j" % "nd4j-native-platform" % "1.0.0-beta5",
+        "org.nd4j" % "nd4j-arrow" % "1.0.0-beta5"
+     )
+  )
 
 lazy val pyj = project
   .settings(commonSettings)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,1 @@
 sbt.version=1.3.2
-

--- a/py4/src/main/scala/com/azavea/nd4j/ExtensionType.scala
+++ b/py4/src/main/scala/com/azavea/nd4j/ExtensionType.scala
@@ -1,0 +1,110 @@
+package com.azavea.nd4j
+
+import org.apache.arrow.flatbuf.Tensor
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.ExtensionTypeVector
+import org.apache.arrow.vector.FieldVector
+import org.apache.arrow.vector.{FixedSizeBinaryVector, IntVector, VarBinaryVector}
+import org.apache.arrow.vector.VectorSchemaRoot
+import org.apache.arrow.vector.holders.NullableVarBinaryHolder
+import org.apache.arrow.vector.ipc.ArrowFileReader
+import org.apache.arrow.vector.ipc.ArrowFileWriter
+import org.apache.arrow.vector.types.pojo._
+import org.apache.arrow.vector.types.pojo.ArrowType.ExtensionType
+import org.nd4j.arrow.ArrowSerde
+import org.nd4j.linalg.api.ndarray.INDArray
+import org.nd4j.linalg.factory.Nd4j
+
+import java.nio.ByteBuffer;
+
+class Nd4jIdentityType extends ExtensionType {
+
+  override def storageType: ArrowType = new ArrowType.Int(32, false)
+
+  override def extensionName: String = "nd4j-identity"
+
+  override def extensionEquals(other: ExtensionType) = other.isInstanceOf[Nd4jIdentityType]
+
+  override def deserialize(otherStorageType: ArrowType, serializedData: String): ArrowType = {
+    if (!otherStorageType.equals(storageType)) {
+      throw new UnsupportedOperationException(s"Cannot construct Nd4jType!  Received type was $otherStorageType, expected $storageType");
+    }
+    new Nd4jIdentityType
+  }
+
+  override def serialize(): String = ""
+
+  override def getNewVector(name: String, fieldType: FieldType, allocator: BufferAllocator): FieldVector = {
+    new Nd4jIdentityVector(name, allocator, new IntVector(name, allocator));
+  }
+
+}
+
+class Nd4jIdentityVector(name: String, allocator: BufferAllocator, underlyingVector: IntVector)
+extends ExtensionTypeVector[IntVector](name, allocator, underlyingVector) {
+
+  def set(index: Int, arrayDim: Int) = {
+    getUnderlyingVector().setSafe(index, arrayDim)
+  }
+
+  override def getObject(index: Int): Object = {
+    Nd4j.eye(getUnderlyingVector.get(index))
+  }
+
+  override def hashCode(index: Int): Int = underlyingVector.hashCode(index)
+
+}
+
+class Nd4jType extends ExtensionType {
+
+  override def storageType: ArrowType = new ArrowType.Binary
+
+  override def extensionName: String = "nd4j"
+
+  override def extensionEquals(other: ExtensionType) = other.isInstanceOf[Nd4jType]
+
+  override def deserialize(otherStorageType: ArrowType, serializedData: String): ArrowType = {
+    if (!otherStorageType.equals(storageType)) {
+      throw new UnsupportedOperationException("Cannot construct Nd4jType from underlying type " + storageType);
+    }
+    new Nd4jType
+  }
+
+  override def serialize(): String = ""
+
+  override def getNewVector(name: String, fieldType: FieldType, allocator: BufferAllocator): FieldVector = {
+    new Nd4jVector(name, allocator, new VarBinaryVector(name, allocator));
+  }
+
+}
+
+class Nd4jVector(name: String, allocator: BufferAllocator, underlyingVector: VarBinaryVector)
+extends ExtensionTypeVector[VarBinaryVector](name, allocator, underlyingVector) {
+
+  def set(index: Int, matr: INDArray) = {
+    val tensBytes = ArrowSerde.toTensor(matr).getByteBuffer
+    val len = tensBytes.position
+    tensBytes.rewind
+    val buf = allocator.buffer(tensBytes.limit)
+
+    println(s"Created buffer $buf\nStarted from buffer with limit ${tensBytes.limit}, length $len, and current position ${tensBytes.position}")
+
+    buf.setBytes(0, tensBytes)
+
+    val holder = new NullableVarBinaryHolder
+    holder.isSet = 1
+    holder.start = 0
+    holder.buffer = buf
+    holder.end = tensBytes.limit
+
+    getUnderlyingVector().setSafe(index, tensBytes.array)
+  }
+
+  override def getObject(index: Int): Object = {
+    val tens = Tensor.getRootAsTensor(ByteBuffer.wrap(underlyingVector.getObject(index)))
+    ArrowSerde.fromTensor(tens)
+  }
+
+  override def hashCode(index: Int): Int = underlyingVector.hashCode(index)
+}

--- a/py4/src/main/scala/com/azavea/nd4j/Main.scala
+++ b/py4/src/main/scala/com/azavea/nd4j/Main.scala
@@ -1,0 +1,80 @@
+package com.azavea.nd4j
+
+import py4j.GatewayServer
+import org.apache.arrow.flatbuf.Tensor
+import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.VectorSchemaRoot
+import org.apache.arrow.vector.ipc.{ArrowFileReader, ArrowFileWriter, ArrowStreamReader}
+import org.apache.arrow.vector.types.pojo._
+import org.nd4j.arrow.ArrowSerde
+import org.nd4j.linalg.api.ndarray.INDArray
+import org.nd4j.linalg.factory.Nd4j
+
+import java.io.File
+import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
+import java.nio.file.{Files, Paths, StandardOpenOption}
+import java.util.Collections
+
+object Nd4jEntryPoint {
+  def main(args: Array[String]): Unit = {
+    ExtensionTypeRegistry.register(new Nd4jIdentityType)
+    val gatewayServer = new GatewayServer(new Nd4jEntryPoint)
+    gatewayServer.start()
+    System.out.println("Gateway Server Started")
+  }
+}
+
+class Nd4jEntryPoint {
+  def identity(n: Int) = {
+    val tens = ArrowSerde.toTensor(Nd4j.eye(n))
+    tens.getByteBuffer.array
+  }
+
+  def send(bytes: Array[Byte]) = {
+    println(s"Received bytes of size ${bytes.size}")
+    val bb = ByteBuffer.wrap(bytes.slice(1, bytes.size))
+    val tens = Tensor.getRootAsTensor(bb)
+    val matr = ArrowSerde.fromTensor(tens)
+    println(matr)
+  }
+
+  def send_batch(bytes: Array[Byte]) = {
+    println(s"Received bytes of size ${bytes.size}")
+    val stream = new java.io.ByteArrayInputStream(bytes)
+    val root = new RootAllocator
+    val asr = new ArrowStreamReader(stream, root)
+    asr.loadNextBatch
+    val schema = asr.getVectorSchemaRoot
+    val vec = schema.getVector("eyes")
+    val n = schema.getRowCount
+    val matrs = Range(0, n).map{ i => vec.getObject(i).asInstanceOf[INDArray] }
+    println(s"Content was $n identity matrices with dimension ${matrs.map{ m => (m.rows, m.columns) }}")
+  }
+}
+
+
+
+object ExtensionTypeTest {
+  def main(args: Array[String]): Unit = {
+    ExtensionTypeRegistry.register(new Nd4jType)
+    val schema = new Schema(Collections.singletonList(Field.nullable("a", new Nd4jType)))
+    val allocator = new RootAllocator(Int.MaxValue)
+    val root = VectorSchemaRoot.create(schema, allocator)
+
+    val matr = Nd4j.eye(40)
+    val vector = root.getVector("a").asInstanceOf[Nd4jVector]
+    vector.setValueCount(1)
+    vector.set(0, matr)
+    root.setRowCount(1)
+
+    val file = File.createTempFile("nd4jtest", ".arrow")
+    val channel = FileChannel.open(Paths.get(file.getAbsolutePath()), StandardOpenOption.WRITE)
+    val writer = new ArrowFileWriter(root, null, channel)
+    writer.start
+    writer.writeBatch
+    writer.end
+  }
+}
+
+class ExtensionTypeEntryPoint

--- a/python/nd4j-test.py
+++ b/python/nd4j-test.py
@@ -1,0 +1,40 @@
+from py4j.java_gateway import JavaGateway
+import numpy as np
+import pyarrow as pa
+
+class Nd4jIdentityType(pa.ExtensionType):
+    def __init__(self):
+        pa.ExtensionType.__init__(self, pa.uint32(), "nd4j-identity")
+
+    def __arrow_ext_serialize__(self):
+        return b''
+
+    @classmethod
+    def __arrow_ext_deserialize__(self, storage_type, serialized):
+        return Nd4jIdentityType()
+
+def ipc_write_batch(batch):
+    stream = pa.BufferOutputStream()
+    writer = pa.RecordBatchStreamWriter(stream, batch.schema)
+    writer.write_batch(batch)
+    writer.close()
+    return stream.getvalue()
+
+gateway = JavaGateway()
+pa.register_extension_type(Nd4jIdentityType())
+
+nd4j_type = Nd4jIdentityType()
+arr = pa.ExtensionArray.from_storage(nd4j_type, pa.array([4, 40], pa.uint32()))
+batch = pa.RecordBatch.from_arrays([arr], ["eyes"])
+buf = ipc_write_batch(batch)
+gateway.entry_point.send_batch(buf.to_pybytes())
+
+eye_recv = gateway.entry_point.identity(4)
+print("received buffer of size", len(eye_recv))
+
+bos = pa.BufferOutputStream()
+tens = pa.Tensor.from_numpy(np.eye(4))
+pa.ipc.write_tensor(tens, bos)
+bos.close()
+byts = bos.getvalue().to_pybytes()
+gateway.entry_point.send(byts)


### PR DESCRIPTION
_This is a WIP PR.  Do not merge._

We need a mechanism to communicate non-primitive data between Python and Scala that we may ultimately employ in a Spark application.  The foundation of this is to simply transfer data via Arrow between the two language environments.  This PR gives a proof of concept of this process.

Arrow 0.15.0 introduces extension types, which allow one to wrap a basic column type such that the fundamental data is transparently decoded on either end as an object of the desired type.  This example represents identity matrices by their dimension using an unsigned 32-bit int.

We show here that this process works, though it leaves some room for improvement, most notably on the Python side.  We are able to send the dimension data to Scala and read them as matrices.  Note that after running `nd4j-test.py`, the Scala process log shows:
```
[info] running (fork) com.azavea.nd4j.Nd4jEntryPoint 
[info] Gateway Server Started
[info] Received bytes of size 432
[info] 13:55:53 Field: Unrecognized extension type: nd4j-identity
[info] 13:55:53 Nd4jBackend: Loaded [CpuBackend] backend
[info] 13:55:53 NativeOpsHolder: Number of threads used for OpenMP: 2
[info] 13:55:53 Nd4jBlas: Number of threads used for OpenMP BLAS: 2
[info] 13:55:53 DefaultOpExecutioner: Backend used: [CPU]; OS: [Linux]
[info] 13:55:53 DefaultOpExecutioner: Cores: [4]; Memory: [3.5GB];
[info] 13:55:53 DefaultOpExecutioner: Blas vendor: [MKL]
[info] Content was 2 identity matrices with dimension Vector((4,4), (40,40))
```
Notice the last line shows that matrix data was read at the receiving end.  See `Nd4jEntryPoint::send_batch` for details.

I am still working on understanding the reverse process of receiving NumPy ndarrays in Python that were transmitted from Scala.